### PR TITLE
Replace `import_tasks` with `include_tasks` for the main task

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Create infrastrucutre
-  import_tasks: create_infra.yml
+  include_tasks: create_infra.yml
   when: data_center_state == 'present'
 
 - name: Remove infrastrucutre
-  import_tasks: remove_infra.yml
+  include_tasks: remove_infra.yml
   when: data_center_state == 'absent'


### PR DESCRIPTION
When using `import_tasks` with conditionals ansible will
apply conditional to all imported tasks.
In our case this will results to a very big log of skipped
tasks.
It is cleaner to use `include_tasks` instead.