### PR TITLE
Add hosted_engine parameter.  Fixes issue #24

### DIFF
--- a/roles/oVirt.hosts/README.md
+++ b/roles/oVirt.hosts/README.md
@@ -24,6 +24,7 @@ The `hosts` list can contain the following parameters:
 | cluster       | UNDEF (Required) | The cluster that the host must connect to.    |
 | timeout       | 1200             | Maximum wait time for the host to be in an UP state.  |
 | poll_interval | 20               | Polling interval to check the host status. |
+| hosted_engine | UNDEF            | Specifies whether to 'deploy' or 'undeploy' hosted-engine to node. |
 
 Dependencies
 ------------

--- a/roles/oVirt.hosts/tasks/main.yml
+++ b/roles/oVirt.hosts/tasks/main.yml
@@ -35,6 +35,7 @@
     override_iptables: true
     timeout: "{{ item.timeout | default(ovirt_hosts_add_timeout) }}"
     poll_interval: "{{ item.poll_interval | default(20) }}"
+    hosted_engine: "{{ item.hosted_engine | default(omit) }}"
   with_items:
     - "{{ hosts | default([]) }}"
   loop_control:


### PR DESCRIPTION
This adds the needed support for hosted-engine setup..  It can only be done when the host is added, and if there is any blockers after adding a host, it can never be used for hosted-engine until those blockers are removed.