### PR TITLE
oVirt.clusters: Add support to set external network providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The items in `clusters` list variable can contain the following parameters:
 | trusted_service     | UNDEF                   | If True enable integration with an OpenAttestation server.|
 | virt                | UNDEF                   | If True, hosts in this cluster will be used to run virtual machines. Default is true. |
 | gluster                      | UNDEF          | If True, hosts in this cluster will be used as Gluster Storage server nodes, and not for running virtual machines. |
+| external_network_providers   | UNDEF          |  List that specify the external network providers available in the cluster. |
 
 More information about the parameters can be found in the [ovirt_clusters](http://docs.ansible.com/ansible/ovirt_cluster_module.html) module documentation.
 

--- a/roles/oVirt.clusters/README.md
+++ b/roles/oVirt.clusters/README.md
@@ -55,6 +55,7 @@ The items in `clusters` list can contain the following parameters:
 | trusted_service     | UNDEF                   | If True enable integration with an OpenAttestation server.|
 | virt                | UNDEF                   | If True, hosts in this cluster will be used to run virtual machines. Default is true. |
 | gluster                      | UNDEF          | If True, hosts in this cluster will be used as Gluster Storage server nodes, and not for running virtual machines. |
+| external_network_providers   | UNDEF          |  List that specify the external network providers available in the cluster. |
 
 More information about the parameters can be found in the [Ansible documentation](http://docs.ansible.com/ansible/ovirt_cluster_module.html).
 

--- a/roles/oVirt.clusters/tasks/main.yml
+++ b/roles/oVirt.clusters/tasks/main.yml
@@ -9,6 +9,7 @@
     compatibility_version: "{{ compatibility_version }}"
     mac_pool: "{{ item.mac_pool | default(omit) }}"
     comment: "{{ item.comment | default(omit) }}"
+    external_network_providers: "{{ item.external_network_providers | default(omit) }}"
     fence_connectivity_threshold: "{{ item.fence_connectivity_threshold | default(omit) }}"
     gluster: "{{ item.gluster | default(omit) }}"
     migration_bandwidth: "{{ item.migration_bandwidth | default(omit) }}"


### PR DESCRIPTION
This requires ansible 2.5.
Closes #22 

Change-Id: I7bbd8ca55fde5587d423d342373126eb84f3cec9
Signed-off-by: Dominik Holler <dholler@redhat.com>