### PR TITLE
Ansible 2.6 don't return ID as list

### DIFF
--- a/roles/oVirt.storages/tasks/main.yml
+++ b/roles/oVirt.storages/tasks/main.yml
@@ -73,7 +73,7 @@
 - name: Validate connections of storages
   ovirt_storage_connections:
     auth: "{{ ovirt_auth }}"
-    id: "{{ item.1.id[0] }}"
+    id: "{{ ansible_version.full is version('2.6.0', '>=') | ternary(item.1.id, item.1.id[0]) }}"
     storage: "{{ item.0.name }}"
     address: "{{ storages[item.0.name][item.0.storage.type].address | default(omit) }}"
     path: "{{ storages[item.0.name][item.0.storage.type].path | default(omit) }}"


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1599055

Since Ansible 2.6 includes following fix:

 https://github.com/ansible/ansible/pull/39736

Which break backward compatibility. We need to make sure we check the
Ansible version and user proper fetch of ID.

Change-Id: I1083da769197aaebac5ca86f87112517ade52496
Signed-off-by: Ondra Machacek <omachace@redhat.com>