### PR TITLE
Add no_log to manage users task

### DIFF
--- a/roles/ovirt.aaa-jdbc/tasks/main.yml
+++ b/roles/ovirt.aaa-jdbc/tasks/main.yml
@@ -3,6 +3,7 @@
 ## User & groups internal
 ################################
 - name: Manage internal users
+  no_log: true
   command: "{{ aaa_jdbc_prefix }}/ovirt-aaa-jdbc-tool user {{ (item.state is undefined or item.state == 'present') | ternary('add','delete') }} {{ item.name }}"
   with_items:
     - "{{ users | default([]) }}"


### PR DESCRIPTION
This patch add no_log: true to manage user task, so we don't print
password in case of failure.

Change-Id: Ic7033dd9b5b4c509564ab04a287028043795eaf5
Signed-off-by: Ondra Machacek <omachace@redhat.com>