### PR TITLE
Document usage of users

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ oVirt Infra
 
 The `ovirt.infra` role enables you to set up oVirt infrastructure including: mac pools, data centers, clusters, networks, hosts, users, and groups.
 
+Target machine
+--------------
+In case you use this role to do user management, it will use `ovirt-aaa-jdbc-tool`, which is located on engine machine,
+so you must execute the role on engine machine.
+
 Note
 ----
 Please note that when installing this role from Ansible Galaxy you are instructed to run following command:

--- a/roles/ovirt.aaa-jdbc/tasks/main.yml
+++ b/roles/ovirt.aaa-jdbc/tasks/main.yml
@@ -2,6 +2,22 @@
 ################################
 ## User & groups internal
 ################################
+- name: Check if ovirt-aaa-jdbc-tool exists
+  stat:
+    path: "{{ aaa_jdbc_prefix }}/ovirt-aaa-jdbc-tool"
+  register: aaa_jdbc_path_stat
+  tags:
+    - ovirt-aaa-jdbc
+    - users
+
+- name: Fail the role if aaa-jdbc-tool don't exist
+  fail:
+    msg: "{{ aaa_jdbc_prefix }}/ovirt-aaa-jdbc-tool doesn't exist, are you on engine machine?"
+  when: not aaa_jdbc_path_stat.stat.exists
+  tags:
+    - ovirt-aaa-jdbc
+    - users
+
 - name: Manage internal users
   no_log: true
   command: "{{ aaa_jdbc_prefix }}/ovirt-aaa-jdbc-tool user {{ (item.state is undefined or item.state == 'present') | ternary('add','delete') }} {{ item.name }}"

--- a/tasks/create_infra.yml
+++ b/tasks/create_infra.yml
@@ -26,6 +26,7 @@
 - name: Run aaa-jdbc sub-role
   import_role:
     name: "ovirt.infra/roles/ovirt.aaa-jdbc"
+  when: users is defined or user_groups is defined
 
 - name: Run external-providers sub-role
   import_role:


### PR DESCRIPTION
When user don't specify users or user_groups don't execute the aaa-jdbc
role.

In case it's specified but aaa-jdbc tool don't exists, print
reasonable error message.

Document this behavior in README.md.

Change-Id: Icd59337effade9f2f7a5598af37086919e9ae3d3
Bug-Url: https://bugzilla.redhat.com/show_bug.cgi?id=1638380
Signed-off-by: Ondra Machacek <omachace@redhat.com>