### PR TITLE
fix host missing required networks

### DIFF
--- a/roles/ovirt.hosts/tasks/main.yml
+++ b/roles/ovirt.hosts/tasks/main.yml
@@ -56,9 +56,17 @@
     label: "{{ item.item.name }}"
   tags:
     - hosts
+  ignore_errors: yes
   until: job_result.finished
   retries: "{{ ovirt_hosts_max_timeout // 20 }}"
   delay: 20
+
+- name: Fail the play with unexpected error
+  fail:
+    msg: The host deploy failed with message '{{ item["exception"] }}'.
+  when: item.failed and "the following networks are missing" not in item["exception"]
+  with_items:
+    - "{{ job_result.results }}"
 
 - name: Set Power Management
   ovirt_host_pm:


### PR DESCRIPTION
When the host has required networks it needs at first create host and then attach them with ovirt_host_network.
Now it will continue when the specific error occurs otherwise it will fail.
https://bugzilla.redhat.com/show_bug.cgi?id=1838144
@mwperina @dangel101