### PR TITLE
automation: drop el7

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -1,5 +1,4 @@
 distros:
-  - el7
   - el8
 release_branches:
   master: [ "ovirt-master" ]


### PR DESCRIPTION
Builds for el7 are with version 1.1.Z 
For el8 1.2.Z