### PR TITLE
Add deprecated info to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 oVirt Infra
 ===========
 
+## This role has been migrated to [oVirt Ansible Collection](https://github.com/ovirt/ovirt-ansible-collection), please use latest version from there. This repository is now readonly and no longer used for active development
+
 The `ovirt.infra` role enables you to set up oVirt infrastructure including: mac pools, data centers, clusters, networks, hosts, users, and groups.
 
 Target machine


### PR DESCRIPTION
The role development was migrated to the ovirt-ansible-collection
https://github.com/ovirt/ovirt-ansible-collection